### PR TITLE
Removed flag from tank object when flag was returned to base

### DIFF
--- a/src/flag.js
+++ b/src/flag.js
@@ -32,6 +32,9 @@ Flag.prototype = {
 			x: this.originalPosition.x,
 			y: this.originalPosition.y
 		}
+		if(this.tankToFollow){
+			this.tankToFollow.hasFlag = false;
+		}
 		this.tankToFollow = null;
 	},
 	slowDeath: function() {


### PR DESCRIPTION
I was watching tank objects and noticed that when a tank drops off a flag, the flag properly removes itself from following the tank, but the hasFlag value of the tank was not reset to false. This pull request fixes that.
